### PR TITLE
PHP Warning fix

### DIFF
--- a/ED_Utils.php
+++ b/ED_Utils.php
@@ -900,7 +900,7 @@ END;
 
 		// do any special variable replacements in the URLs, for
 		// secret API keys and the like
-		foreach ( $edgStringReplacements as $key => $value ) {
+		foreach ( (array) $edgStringReplacements as $key => $value ) {
 			$url = str_replace( $key, $value, $url );
 		}
 


### PR DESCRIPTION
Cast $edgStringReplacements to an array to prevent 'Invalid argument supplied for foreach' warnings.