### PR TITLE
Adding 'type' to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,7 @@
 	"name": "mediawiki/external-data",
 	"description": "Allows retrieving structured data from external URLs, databases and other sources into MediaWiki-powered wikis",
 	"license": "GPL-2.0-or-later",
+	"type": "mediawiki-extension",
 	"require": {
 		"symfony/css-selector": "~5.1"
 	},


### PR DESCRIPTION
Adding the "type" to composer.json to define this as an extension. Otherwise it gets installed in the vendor directory.